### PR TITLE
Selenium Test Improvements

### DIFF
--- a/SimpleDemoApp/SimpleDemoApp.WebDriver/ChromeTests.cs
+++ b/SimpleDemoApp/SimpleDemoApp.WebDriver/ChromeTests.cs
@@ -67,7 +67,7 @@ namespace SimpleDemoApp.WebDriver
             string actualPageTitle = _webDriver.Title;
             string expectedPageTitle = "Home Page - My ASP.NET Application";
 
-            Assert.AreEqual(actualPageTitle, expectedPageTitle);
+            Assert.AreEqual(expectedPageTitle, actualPageTitle);
         }
 
         [TestMethod]
@@ -79,7 +79,7 @@ namespace SimpleDemoApp.WebDriver
             string actualPageTitle = _webDriver.Title;
             string expectedPageTitle = "About - My ASP.NET Application";
 
-            Assert.AreEqual(actualPageTitle, expectedPageTitle);
+            Assert.AreEqual(expectedPageTitle, actualPageTitle);
         }
 
         [TestMethod]
@@ -91,7 +91,7 @@ namespace SimpleDemoApp.WebDriver
             string actualPageTitle = _webDriver.Title;
             string expectedPageTitle = "Contact - My ASP.NET Application";
 
-            Assert.AreEqual(actualPageTitle, expectedPageTitle);
+            Assert.AreEqual(expectedPageTitle, actualPageTitle);
         }
 
         [TestMethod]
@@ -103,7 +103,7 @@ namespace SimpleDemoApp.WebDriver
             _webDriver.Url = _webAppBaseURL + "/Home/Contact";
             RemoteWebElement supportEmailElement = (RemoteWebElement)_webDriver.FindElementByLinkText(supportEmailAddress);
 
-            Assert.AreEqual(supportEmailElement.Text, supportEmailAddress);
+            Assert.AreEqual(supportEmailAddress, supportEmailElement.Text);
         }
 
         [TestMethod]
@@ -115,7 +115,7 @@ namespace SimpleDemoApp.WebDriver
             _webDriver.Url = _webAppBaseURL + "/Home/Contact";
             RemoteWebElement marketingEmailElement = (RemoteWebElement)_webDriver.FindElementByLinkText(marketingEmailAddress);
 
-            Assert.AreEqual(marketingEmailElement.Text, marketingEmailAddress);
+            Assert.AreEqual(marketingEmailAddress, marketingEmailElement.Text);
         }
 
     }

--- a/SimpleDemoApp/SimpleDemoApp.WebDriver/ChromeTests.cs
+++ b/SimpleDemoApp/SimpleDemoApp.WebDriver/ChromeTests.cs
@@ -11,8 +11,8 @@ namespace SimpleDemoApp.WebDriver
 
         private static RemoteWebDriver _webDriver = null;
         private static string _webAppBaseURL;
-        // A website I always keep running. Use to show working in VS, remove if prefer to show failure
-        private static string _defaultWebAppBaseURL = "http://gdaviwebappdev.azurewebsites.net";
+        // A website kept running and not changed. Use to show working in VS, remove if prefer to show failure
+        private static string _defaultWebAppBaseURL = "http://deployedsimplewebapp.azurewebsites.net/";
 
         [ClassInitialize()]
         // All tests in this class are going to use Chrome, therefore set the Chrome driver up once here
@@ -56,6 +56,18 @@ namespace SimpleDemoApp.WebDriver
             {
                 _webDriver.Quit();
             }
+        }
+
+        [TestMethod]
+        [TestCategory("UI")]
+        public void IndexTitleChromeTest()
+        {
+            string expectedTitle = "ASP.NET";
+            
+            _webDriver.Url = _webAppBaseURL + "/Home/Index";
+            RemoteWebElement titleElement = (RemoteWebElement)_webDriver.FindElementByTagName("H1");
+
+            Assert.AreEqual(expectedTitle, titleElement.Text);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixing a few things that have bothered me:

1. Timeout increased to allow for JIT
2. Corrected assertion param order (I put them all in backwards for some reason)
3. Set default site to hit as a new site that I won't change at all - therefore can't impact your demos
4. Added a test to check the title, assumes ASP.NET which is in the new deployed site
5. Main one - now picks up the Env variable WebAppName from the release environment and uses that URL to test against - so no need for hard coding of URL. Note that the title test will fail if not kept in sync with title change in the app - but that can be used to show a failure easily.